### PR TITLE
feat: add a root level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: all lexer namo parser clean
+
+all: lexer namo parser
+
+lexer:
+	$(MAKE) -C Lexer
+
+namo:
+	$(MAKE) -C "Namo (Text-Editor)"
+
+PARSER_DIR := Parser
+PARSER_SRCS := $(PARSER_DIR)/file_io.c $(PARSER_DIR)/utils.c $(PARSER_DIR)/Tokens.c
+PARSER_OBJS := $(PARSER_SRCS:.c=.o)
+PARSER_LIB := $(PARSER_DIR)/libparser.a
+
+parser: $(PARSER_LIB)
+
+$(PARSER_LIB): $(PARSER_OBJS)
+	ar rcs $@ $^
+
+$(PARSER_DIR)/%.o: $(PARSER_DIR)/%.c
+	$(CC) -Wall -Wextra -std=c11 -O2 -c $< -o $@
+
+clean:
+	$(MAKE) -C Lexer clean
+	$(MAKE) -C "Namo (Text-Editor)" clean
+	$(RM) $(PARSER_OBJS) $(PARSER_LIB)

--- a/Namo (Text-Editor)/makefile
+++ b/Namo (Text-Editor)/makefile
@@ -5,7 +5,7 @@ PKG_CFLAGS = $(shell pkg-config --cflags sdl2 SDL2_ttf freetype2 harfbuzz)
 PKG_LIBS = $(shell pkg-config --libs sdl2 SDL2_ttf freetype2 harfbuzz)
 
 # Source files and target
-SRC = main.c la.c lexer.c editor.c
+SRC = main.c la.c editor.c
 OBJ = $(SRC:.c=.o)
 TARGET = NAmo
 


### PR DESCRIPTION
- Added a root-level Makefile to easliy build Lexer, Namo, and Parser.
- Parser currently builds into a static library (`libparser.a`).
- Kept existing sub-Makefiles for Lexer and Namo (for now, being used by the root-level Makefile).
- Added convenient top-level targets: `all`, `lexer`, `namo`, `parser`, `clean`.